### PR TITLE
Drop unused openjdk-r PPA from handle-server image

### DIFF
--- a/handle-server/Dockerfile
+++ b/handle-server/Dockerfile
@@ -7,7 +7,6 @@ LABEL Name=handle_server_postgres Version=1.0.0
 CMD ["/sbin/my_init"]
 
 # Update installed APT packages
-RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
 
 RUN apt-get install -y ntp wget openjdk-11-jdk python3 libpostgresql-jdbc-java


### PR DESCRIPTION
The ppa:openjdk-r/ppa was added but openjdk-11-jdk is already available in Ubuntu 22.04 (jammy) main repos used by the base image. The PPA only added a network round-trip to launchpad.net, which intermittently times out and fails the CI build.