### PR TITLE
Change docker restart to not autostart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: ./handle-server
       dockerfile: Dockerfile
-    restart: always
+    restart: on-failure:3
     ports:
       - "2641:2641/udp"
       - "2641:2641/tcp"


### PR DESCRIPTION
Change from "always" which causes the container to start when docker engine is started to "on-failure" (with 3 re-tries) which does not re-start a normally (=no error) stopped container.